### PR TITLE
fix 2 warnings in rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ export default [
     output: {
       file: 'dist/index.es.js', format: 'es',
     },
+    external: ['react'],
     plugins: [
       typescript(),
       babel({
@@ -27,7 +28,11 @@ export default [
       format: 'umd',
       name: 'reactUseThrottle',
       indent: false,
+      globals: {
+        react: 'react',
+      },
     },
+    external: ['react'],
     plugins: [
       typescript(),
       babel({


### PR DESCRIPTION
I fixed two warnings in rollup.

1.
```bash
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
react (imported by src/useThrottle.ts)
```
2.
```bash
(!) Missing global variable name
Use output.globals to specify browser global variable names corresponding to external modules
react (guessing 'react')
```
